### PR TITLE
Add configurable prefixes to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ sonarr-url-base=
 # The max number of results to show per search command (default is 20)
 # If you set this to any value less than 0, the bot won't startup
 #max-results-to-show=20
+
+# The command prefix (default is /)
+# Any prefix is allowed (but I haven't tested every single prefix in every client)
+command-prefix=/
 ```
 
 1. Run the jar using java

--- a/sample.properties
+++ b/sample.properties
@@ -55,3 +55,7 @@ max-downloads-to-show=20
 # The max number of results to show per search command (default is 20)
 # If you set this to any value less than 0, the bot won't startup
 max-results-to-show=20
+
+# The command prefix (default is /)
+# Any prefix is allowed (but I haven't tested every single prefix in every client)
+command-prefix=/

--- a/src/main/java/com/botdarr/Config.java
+++ b/src/main/java/com/botdarr/Config.java
@@ -68,6 +68,11 @@ public class Config {
       if (!this.isSonarrEnabled) {
         LOGGER.warn("Sonarr commands are not enabled, make sure you set the sonarr url, path, token, default profile");
       }
+
+      String configuredPrefix = properties.getProperty(Config.Constants.COMMAND_PREFIX);
+      if (!Strings.isEmpty(configuredPrefix)  && configuredPrefix.length() > 1) {
+        throw new RuntimeException("Command prefix must be a single character");
+      }
     } catch (Exception ex) {
       LOGGER.error("Error loading properties file", ex);
       throw new RuntimeException(ex);
@@ -205,6 +210,11 @@ public class Config {
      * The max number of results to show per search command
      */
     public static final String MAX_RESULTS_TO_SHOW = "max-results-to-show";
+
+    /**
+     * The prefix for all commands
+     */
+    public static final String COMMAND_PREFIX = "command-prefix";
   }
 
   private static String propertiesPath = "config/properties";

--- a/src/main/java/com/botdarr/commands/Command.java
+++ b/src/main/java/com/botdarr/commands/Command.java
@@ -6,5 +6,9 @@ public interface Command {
   public String getCommandText();
   public String getDescription();
   public String getIdentifier();
+  public default boolean hasArguments() {
+    //by default all commands have arguments unless explicitly overridden
+    return true;
+  }
   public CommandResponse<? extends ChatClientResponse> execute(String command);
 }

--- a/src/main/java/com/botdarr/commands/CommandProcessor.java
+++ b/src/main/java/com/botdarr/commands/CommandProcessor.java
@@ -26,7 +26,7 @@ public class CommandProcessor {
           String command = apiCommand.getIdentifier().toLowerCase();
           boolean foundCommand = apiCommand.hasArguments() ? rawMessageWithoutPrefix.startsWith(command) : rawMessageWithoutPrefix.equalsIgnoreCase(command);
           if (foundCommand) {
-            String commandOperation = rawMessage.replaceAll(command, "");
+            String commandOperation = rawMessageWithoutPrefix.replaceAll(command, "");
             try {
               CommandContext
                 .start()

--- a/src/main/java/com/botdarr/commands/CommandProcessor.java
+++ b/src/main/java/com/botdarr/commands/CommandProcessor.java
@@ -1,0 +1,59 @@
+package com.botdarr.commands;
+
+import com.botdarr.Config;
+import com.botdarr.api.Api;
+import com.botdarr.clients.ChatClientResponse;
+import com.botdarr.clients.ChatClientResponseBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.util.Strings;
+
+import java.util.List;
+
+public class CommandProcessor {
+  public <T extends ChatClientResponse, Z extends Api> CommandResponse processMessage(List<Command> apiCommands,
+                                                                               String strippedMessage,
+                                                                               String username,
+                                                                               ChatClientResponseBuilder<T> chatClientResponseBuilder) {
+    try {
+      String rawMessage = strippedMessage.toLowerCase();
+      String commandPrefix = getPrefix();
+
+      if (rawMessage.startsWith(commandPrefix)) {
+        //remove the prefix character from the message
+        String rawMessageWithoutPrefix = rawMessage.trim().substring(1);
+        for (Command apiCommand : apiCommands) {
+          String command = apiCommand.getIdentifier().toLowerCase();
+          boolean foundCommand = apiCommand.hasArguments() ? rawMessageWithoutPrefix.startsWith(command) : rawMessageWithoutPrefix.equalsIgnoreCase(command);
+          if (foundCommand) {
+            String commandOperation = rawMessage.replaceAll(command, "");
+            try {
+              CommandContext
+                .start()
+                .setUsername(username);
+              return apiCommand.execute(commandOperation.trim());
+            } finally {
+              CommandContext.end();
+            }
+          }
+        }
+        return new CommandResponse(chatClientResponseBuilder.createErrorMessage("Invalid command - type " + commandPrefix + "help for command usage"));
+      }
+
+    } catch (Exception e) {
+      LOGGER.error("Error trying to execute command " + strippedMessage, e);
+      return new CommandResponse(chatClientResponseBuilder.createErrorMessage("Error trying to parse command " + strippedMessage  + ", error=" + e.getMessage()));
+    }
+    return null;
+  }
+
+  String getPrefix() {
+    String configuredPrefix = Config.getProperty(Config.Constants.COMMAND_PREFIX);
+    if (!Strings.isEmpty(configuredPrefix)) {
+      return configuredPrefix;
+    }
+    return "/";
+  }
+
+  private static final Logger LOGGER = LogManager.getLogger(CommandProcessor.class);
+}

--- a/src/main/java/com/botdarr/commands/HelpCommands.java
+++ b/src/main/java/com/botdarr/commands/HelpCommands.java
@@ -11,24 +11,36 @@ public class HelpCommands {
                                           List<Command> radarrCommands,
                                           List<Command> sonarrCommands) {
     return new ArrayList<Command>() {{
-      add(new BaseCommand("help", "") {
+      add(new BaseHelpCommand("help", "") {
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           return new CommandResponse(chatClientResponseBuilder.getHelpResponse());
         }
       });
-      add(new BaseCommand("movies help", "") {
+      add(new BaseHelpCommand("movies help", "") {
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           return new CommandResponse(chatClientResponseBuilder.getMoviesHelpResponse(radarrCommands));
         }
       });
-      add(new BaseCommand("shows help", "") {
+      add(new BaseHelpCommand("shows help", "") {
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           return new CommandResponse(chatClientResponseBuilder.getShowsHelpResponse(sonarrCommands));
         }
       });
     }};
+  }
+
+  private static abstract class BaseHelpCommand extends BaseCommand {
+
+    public BaseHelpCommand(String commandText, String description) {
+      super(commandText, description);
+    }
+
+    @Override
+    public boolean hasArguments() {
+      return false;
+    }
   }
 }

--- a/src/main/java/com/botdarr/commands/RadarrCommands.java
+++ b/src/main/java/com/botdarr/commands/RadarrCommands.java
@@ -112,6 +112,10 @@ public class RadarrCommands {
     }};
   }
 
+  public static String getAddMovieCommandStr(String title, long tmdbId) {
+    return new CommandProcessor().getPrefix() + "movie id add " + title + " " + tmdbId;
+  }
+
   private static void validateMovieTitle(String movieTitle) {
     if (Strings.isEmpty(movieTitle)) {
       throw new IllegalArgumentException("Movie title is missing");

--- a/src/main/java/com/botdarr/commands/RadarrCommands.java
+++ b/src/main/java/com/botdarr/commands/RadarrCommands.java
@@ -2,6 +2,7 @@ package com.botdarr.commands;
 
 import com.botdarr.clients.ChatClientResponse;
 import com.botdarr.api.RadarrApi;
+import org.apache.logging.log4j.util.Strings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,6 +11,11 @@ public class RadarrCommands {
   public static List<Command> getCommands(RadarrApi radarrApi) {
     return new ArrayList<Command>() {{
       add(new BaseCommand("movie discover", "Finds new movies based on radarr recommendations (from trakt)") {
+        @Override
+        public boolean hasArguments() {
+          return false;
+        }
+
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           return new CommandResponse<>(radarrApi.discover());
@@ -22,6 +28,17 @@ public class RadarrCommands {
           int lastSpace = command.lastIndexOf(" ");
           String searchText = command.substring(0, lastSpace);
           String id = command.substring(lastSpace + 1);
+          if (Strings.isEmpty(searchText)) {
+            throw new IllegalArgumentException("Movie title is missing");
+          }
+          if (Strings.isEmpty(id)) {
+            throw new IllegalArgumentException("Movie id is missing");
+          }
+          try {
+            Integer.valueOf(id);
+          } catch (NumberFormatException e) {
+            throw new RuntimeException("Movie id is not a number");
+          }
           return new CommandResponse(radarrApi.addWithId(searchText, id));
         }
       });
@@ -32,19 +49,24 @@ public class RadarrCommands {
           return new CommandResponse(radarrApi.addWithTitle(command));
         }
       });
-      add(new BaseCommand("movie profiles", "Displays all the profiles available to search for movies under (i.e., movie title add ANY)") {
+      add(new BaseCommand("movie profiles", "Displays all the profiles available to search for movies under (i.e., movie title add MOVIE_TITLE_HERE)") {
+        @Override
+        public boolean hasArguments() {
+          return false;
+        }
+
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           return new CommandResponse(radarrApi.getProfiles());
         }
       });
-      add(new BaseCommand("movie find new", "Finds a new movie using radarr (i.e., movie find John Wick)") {
+      add(new BaseCommand("movie find new", "Finds a new movie using radarr (i.e., movie find new John Wick)") {
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           return new CommandResponse(radarrApi.lookup(command, true));
         }
       });
-      add(new BaseCommand("movie find existing", "Finds an existing movie using radarr (i.e., movie find Princess Fudgecake)") {
+      add(new BaseCommand("movie find existing", "Finds an existing movie using radarr (i.e., movie find existing Princess Fudgecake)") {
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           return new CommandResponse(radarrApi.lookup(command, false));
@@ -72,6 +94,11 @@ public class RadarrCommands {
         }
       });
       add(new BaseCommand("movie downloads", "Shows all the active movies downloading in radarr") {
+        @Override
+        public boolean hasArguments() {
+          return false;
+        }
+
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           return new CommandResponse(radarrApi.downloads());

--- a/src/main/java/com/botdarr/commands/SonarrCommands.java
+++ b/src/main/java/com/botdarr/commands/SonarrCommands.java
@@ -28,11 +28,21 @@ public class SonarrCommands {
       });
       add(new BaseCommand("show downloads", "Shows all the active shows downloading in sonarr") {
         @Override
+        public boolean hasArguments() {
+          return false;
+        }
+
+        @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           return new CommandResponse(sonarrApi.downloads());
         }
       });
       add(new BaseCommand("show profiles", "Displays all the profiles available to search for shows under (i.e., show add ANY)") {
+        @Override
+        public boolean hasArguments() {
+          return false;
+        }
+
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           return new CommandResponse(sonarrApi.getProfiles());

--- a/src/main/java/com/botdarr/commands/SonarrCommands.java
+++ b/src/main/java/com/botdarr/commands/SonarrCommands.java
@@ -2,6 +2,7 @@ package com.botdarr.commands;
 
 import com.botdarr.api.SonarrApi;
 import com.botdarr.clients.ChatClientResponse;
+import org.apache.logging.log4j.util.Strings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,8 +15,13 @@ public class SonarrCommands {
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
           int lastSpace = command.lastIndexOf(" ");
+          if (lastSpace == -1) {
+            throw new RuntimeException("Missing expected arguments - usage: show id add SHOW_TITLE_HERE SHOW_ID_HERE");
+          }
           String searchText = command.substring(0, lastSpace);
           String id = command.substring(lastSpace + 1);
+          validateShowTitle(searchText);
+          validateShowId(id);
           return new CommandResponse(sonarrApi.addWithId(searchText, id));
         }
       });
@@ -23,6 +29,7 @@ public class SonarrCommands {
         " we will either add the show or return all the shows that match your search.") {
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
+          validateShowTitle(command);
           return new CommandResponse(sonarrApi.addWithTitle(command));
         }
       });
@@ -51,15 +58,34 @@ public class SonarrCommands {
       add(new BaseCommand("show find existing", "Finds a existing show using sonarr (i.e., show find existing Ahh! Real fudgecakes)") {
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
+          validateShowTitle(command);
           return new CommandResponse(sonarrApi.lookup(command, false));
         }
       });
       add(new BaseCommand("show find new", "Finds a new show using sonarr (i.e., show find new Fresh Prince of Fresh air)") {
         @Override
         public CommandResponse<? extends ChatClientResponse> execute(String command) {
+          validateShowTitle(command);
           return new CommandResponse(sonarrApi.lookup(command, true));
         }
       });
     }};
+  }
+
+  private static void validateShowTitle(String movieTitle) {
+    if (Strings.isEmpty(movieTitle)) {
+      throw new IllegalArgumentException("Show title is missing");
+    }
+  }
+
+  private static void validateShowId(String id) {
+    if (Strings.isEmpty(id)) {
+      throw new IllegalArgumentException("Show id is missing");
+    }
+    try {
+      Integer.valueOf(id);
+    } catch (NumberFormatException e) {
+      throw new RuntimeException("Show id is not a number");
+    }
   }
 }

--- a/src/main/java/com/botdarr/commands/SonarrCommands.java
+++ b/src/main/java/com/botdarr/commands/SonarrCommands.java
@@ -72,6 +72,10 @@ public class SonarrCommands {
     }};
   }
 
+  public static String getAddShowCommandStr(String title, long tvdbId) {
+    return new CommandProcessor().getPrefix() + "show id add " + title + " " + tvdbId;
+  }
+
   private static void validateShowTitle(String movieTitle) {
     if (Strings.isEmpty(movieTitle)) {
       throw new IllegalArgumentException("Show title is missing");

--- a/src/main/java/com/botdarr/discord/DiscordResponseBuilder.java
+++ b/src/main/java/com/botdarr/discord/DiscordResponseBuilder.java
@@ -5,6 +5,8 @@ import com.botdarr.api.sonarr.*;
 import com.botdarr.clients.ChatClientResponseBuilder;
 import com.botdarr.api.radarr.*;
 import com.botdarr.commands.Command;
+import com.botdarr.commands.RadarrCommands;
+import com.botdarr.commands.SonarrCommands;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import org.apache.commons.io.FileUtils;
@@ -61,7 +63,7 @@ public class DiscordResponseBuilder implements ChatClientResponseBuilder<Discord
     EmbedBuilder embedBuilder = new EmbedBuilder();
     embedBuilder.setTitle(show.getTitle());
     embedBuilder.addField("TvdbId", "" + show.getTvdbId(), false);
-    embedBuilder.addField(ADD_SHOW_COMMAND_FIELD_PREFIX, "show id add " + show.getTitle() + " " + show.getTvdbId(), false);
+    embedBuilder.addField(ADD_SHOW_COMMAND_FIELD_PREFIX, SonarrCommands.getAddShowCommandStr(show.getTitle(), show.getTvdbId()), false);
     embedBuilder.setImage(show.getRemotePoster());
     return new DiscordResponse(embedBuilder.build());
   }
@@ -176,7 +178,7 @@ public class DiscordResponseBuilder implements ChatClientResponseBuilder<Discord
     embedBuilder.setTitle(sonarrShow.getTitle());
     embedBuilder.addField("TvdbId", "" + sonarrShow.getTvdbId(), true);
     if (findNew) {
-      embedBuilder.addField(ADD_SHOW_COMMAND_FIELD_PREFIX, "show id add " + sonarrShow.getTitle() + " " + sonarrShow.getTvdbId(), false);
+      embedBuilder.addField(ADD_SHOW_COMMAND_FIELD_PREFIX, SonarrCommands.getAddShowCommandStr(sonarrShow.getTitle(), sonarrShow.getTvdbId()), false);
     } else {
       embedBuilder.addField("Id", "" + existingShow.getId(), true);
       if (existingShow.getSeasons() != null) {
@@ -198,7 +200,7 @@ public class DiscordResponseBuilder implements ChatClientResponseBuilder<Discord
     embedBuilder.setTitle(radarrMovie.getTitle());
     embedBuilder.addField("TmdbId", "" + radarrMovie.getTmdbId(), false);
     if (findNew) {
-      embedBuilder.addField(ADD_MOVIE_COMMAND_FIELD_PREFIX, "movie id add " + radarrMovie.getTitle() + " " + radarrMovie.getTmdbId(), false);
+      embedBuilder.addField(ADD_MOVIE_COMMAND_FIELD_PREFIX, RadarrCommands.getAddMovieCommandStr(radarrMovie.getTitle(), radarrMovie.getTmdbId()), false);
     } else {
       embedBuilder.addField("Id", "" + existingMovie.getId(), false);
       embedBuilder.addField("Downloaded", existingMovie.isDownloaded() + "", false);
@@ -213,7 +215,7 @@ public class DiscordResponseBuilder implements ChatClientResponseBuilder<Discord
     EmbedBuilder embedBuilder = new EmbedBuilder();
     embedBuilder.setTitle(radarrMovie.getTitle());
     embedBuilder.addField("TmdbId", "" + radarrMovie.getTmdbId(), false);
-    embedBuilder.addField(ADD_MOVIE_COMMAND_FIELD_PREFIX, "movie id add " + radarrMovie.getTitle() + " " + radarrMovie.getTmdbId(), false);
+    embedBuilder.addField(ADD_MOVIE_COMMAND_FIELD_PREFIX, RadarrCommands.getAddMovieCommandStr(radarrMovie.getTitle(), radarrMovie.getTmdbId()), false);
     embedBuilder.setImage(radarrMovie.getRemotePoster());
     return new DiscordResponse(embedBuilder.build());
   }

--- a/src/main/java/com/botdarr/slack/SlackResponseBuilder.java
+++ b/src/main/java/com/botdarr/slack/SlackResponseBuilder.java
@@ -5,6 +5,8 @@ import com.botdarr.api.radarr.*;
 import com.botdarr.api.sonarr.*;
 import com.botdarr.clients.ChatClientResponseBuilder;
 import com.botdarr.commands.Command;
+import com.botdarr.commands.RadarrCommands;
+import com.botdarr.commands.SonarrCommands;
 import com.github.seratch.jslack.api.model.block.ContextBlock;
 import com.github.seratch.jslack.api.model.block.ContextBlockElement;
 import com.github.seratch.jslack.api.model.block.ImageBlock;
@@ -308,7 +310,7 @@ public class SlackResponseBuilder implements ChatClientResponseBuilder<SlackResp
       .build());
     if (findNew) {
       slackResponse.addBlock(SectionBlock.builder()
-        .text(MarkdownTextObject.builder().text(ADD_SHOW_COMMAND_FIELD_PREFIX + " - " + "show id add " + sonarrShow.getTitle() + " " + sonarrShow.getTvdbId()).build())
+        .text(MarkdownTextObject.builder().text(ADD_SHOW_COMMAND_FIELD_PREFIX + " - " + SonarrCommands.getAddShowCommandStr(sonarrShow.getTitle(), sonarrShow.getTvdbId())).build())
         .build());
     } else {
       slackResponse.addBlock(SectionBlock.builder()
@@ -349,7 +351,7 @@ public class SlackResponseBuilder implements ChatClientResponseBuilder<SlackResp
       .build());
     if (findNew) {
       slackResponse.addBlock(SectionBlock.builder()
-        .text(MarkdownTextObject.builder().text(ADD_MOVIE_COMMAND_FIELD_PREFIX + " - " + "movie id add " + lookupMovie.getTitle() + " " + lookupMovie.getTmdbId()).build())
+        .text(MarkdownTextObject.builder().text(ADD_MOVIE_COMMAND_FIELD_PREFIX + " - " + RadarrCommands.getAddMovieCommandStr(lookupMovie.getTitle(), lookupMovie.getTmdbId())).build())
         .build());
     } else {
       slackResponse.addBlock(SectionBlock.builder()
@@ -379,7 +381,7 @@ public class SlackResponseBuilder implements ChatClientResponseBuilder<SlackResp
       .text(MarkdownTextObject.builder().text("TmdbId - " + radarrMovie.getTmdbId()).build())
       .build());
     slackResponse.addBlock(SectionBlock.builder()
-      .text(MarkdownTextObject.builder().text(ADD_MOVIE_COMMAND_FIELD_PREFIX + " - " + "movie id add " + radarrMovie.getTitle() + " " + radarrMovie.getTmdbId()).build())
+      .text(MarkdownTextObject.builder().text(ADD_MOVIE_COMMAND_FIELD_PREFIX + " - " + RadarrCommands.getAddMovieCommandStr(radarrMovie.getTitle(), radarrMovie.getTmdbId())).build())
       .build());
     if (!Strings.isBlank(radarrMovie.getRemotePoster())) {
       //if there is no poster to display, slack will fail to render all the blocks

--- a/src/main/java/com/botdarr/telegram/TelegramResponseBuilder.java
+++ b/src/main/java/com/botdarr/telegram/TelegramResponseBuilder.java
@@ -5,6 +5,8 @@ import com.botdarr.api.radarr.*;
 import com.botdarr.api.sonarr.*;
 import com.botdarr.clients.ChatClientResponseBuilder;
 import com.botdarr.commands.Command;
+import com.botdarr.commands.RadarrCommands;
+import com.botdarr.commands.SonarrCommands;
 import j2html.tags.DomContent;
 import org.apache.commons.io.FileUtils;
 
@@ -201,7 +203,7 @@ public class TelegramResponseBuilder implements ChatClientResponseBuilder<Telegr
     domContents.add(b("*Title* - " + sonarrShow.getTitle()));
     domContents.add(code("TvdbId - " + sonarrShow.getTvdbId()));
     if (findNew) {
-      domContents.add(u(ADD_SHOW_COMMAND_FIELD_PREFIX + " - " + "show id add " + sonarrShow.getTitle() + " " + sonarrShow.getTvdbId()));
+      domContents.add(u(ADD_SHOW_COMMAND_FIELD_PREFIX + " - " + SonarrCommands.getAddShowCommandStr(sonarrShow.getTitle(), sonarrShow.getTvdbId())));
     } else {
       StringBuilder existingShowDetails = new StringBuilder();
       existingShowDetails.append("Number of seasons - " + existingShow.getSeasons().size() + "\n");
@@ -220,7 +222,7 @@ public class TelegramResponseBuilder implements ChatClientResponseBuilder<Telegr
     List<DomContent> domContents = new ArrayList<>();
     domContents.add(b(lookupMovie.getTitle()));
     if (findNew) {
-      domContents.add(u(ADD_MOVIE_COMMAND_FIELD_PREFIX + " - " + "movie id add " + lookupMovie.getTitle() + " " + lookupMovie.getTmdbId()));
+      domContents.add(u(ADD_MOVIE_COMMAND_FIELD_PREFIX + " - " + RadarrCommands.getAddMovieCommandStr(lookupMovie.getTitle(), lookupMovie.getTmdbId())));
     } else {
       StringBuilder existingDetails = new StringBuilder();
       existingDetails.append("Id - " + existingMovie.getId() + "\n");
@@ -237,7 +239,7 @@ public class TelegramResponseBuilder implements ChatClientResponseBuilder<Telegr
     List<DomContent> domContents = new ArrayList<>();
     domContents.add(b(radarrMovie.getTitle()));
     domContents.add(text("TmdbId - " + radarrMovie.getTmdbId()));
-    domContents.add(u(b(ADD_MOVIE_COMMAND_FIELD_PREFIX + " - " + "movie id add " + radarrMovie.getTitle() + " " + radarrMovie.getTmdbId())));
+    domContents.add(u(b(ADD_MOVIE_COMMAND_FIELD_PREFIX + " - " + RadarrCommands.getAddMovieCommandStr(radarrMovie.getTitle(), radarrMovie.getTmdbId()))));
     domContents.add(a(radarrMovie.getRemotePoster()));
     return new TelegramResponse(domContents);
   }

--- a/src/test/java/com/botdarr/ConfigTests.java
+++ b/src/test/java/com/botdarr/ConfigTests.java
@@ -18,6 +18,18 @@ public class ConfigTests {
   }
 
   @Test
+  public void getConfig_invalidCommandPrefixConfigured() throws Exception {
+  Properties properties = new Properties();
+    properties.put("discord-token", "#$F#$#");
+    properties.put("discord-channels", "channel1");
+    properties.put("command-prefix", "//");
+    writeFakePropertiesFile(properties);
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage("Command prefix must be a single character");
+    Config.getProperty("");
+  }
+
+  @Test
   public void getConfig_noChatClientsConfigured() throws Exception {
     writeFakePropertiesFile(new Properties());
     expectedException.expect(RuntimeException.class);

--- a/src/test/java/com/botdarr/TestResponse.java
+++ b/src/test/java/com/botdarr/TestResponse.java
@@ -1,0 +1,34 @@
+package com.botdarr;
+
+import com.botdarr.api.radarr.RadarrMovie;
+import com.botdarr.api.radarr.RadarrQueue;
+import com.botdarr.clients.ChatClientResponse;
+
+public class TestResponse implements ChatClientResponse {
+  public TestResponse() {}
+  public TestResponse(RadarrMovie radarrMovie) {
+    this.radarrMovie = radarrMovie;
+  }
+  public TestResponse(String responseMessage) {
+    this.responseMessage = responseMessage;
+  }
+  public TestResponse(RadarrQueue radarrQueue) {
+    this.radarrQueue = radarrQueue;
+  }
+
+  public String getResponseMessage() {
+    return responseMessage;
+  }
+
+  public RadarrMovie getRadarrMovie() {
+    return radarrMovie;
+  }
+
+  public RadarrQueue getRadarrQueue() {
+    return radarrQueue;
+  }
+
+  private String responseMessage;
+  private RadarrMovie radarrMovie;
+  private RadarrQueue radarrQueue;
+}

--- a/src/test/java/com/botdarr/TestResponseBuilder.java
+++ b/src/test/java/com/botdarr/TestResponseBuilder.java
@@ -1,0 +1,96 @@
+package com.botdarr;
+
+import com.botdarr.api.radarr.RadarrMovie;
+import com.botdarr.api.radarr.RadarrProfile;
+import com.botdarr.api.radarr.RadarrQueue;
+import com.botdarr.api.radarr.RadarrTorrent;
+import com.botdarr.api.sonarr.SonarrProfile;
+import com.botdarr.api.sonarr.SonarrQueue;
+import com.botdarr.api.sonarr.SonarrShow;
+import com.botdarr.clients.ChatClientResponseBuilder;
+import com.botdarr.commands.Command;
+
+import java.util.List;
+
+public class TestResponseBuilder implements ChatClientResponseBuilder<TestResponse> {
+
+  @Override
+  public TestResponse getHelpResponse() {
+    return new TestResponse();
+  }
+
+  @Override
+  public TestResponse getMoviesHelpResponse(List<Command> radarrCommands) {
+    return new TestResponse();
+  }
+
+  @Override
+  public TestResponse getShowsHelpResponse(List<Command> sonarrCommands) {
+    return new TestResponse();
+  }
+
+  @Override
+  public TestResponse getShowResponse(SonarrShow show) {
+    return new TestResponse();
+  }
+
+  @Override
+  public TestResponse getShowDownloadResponses(SonarrQueue sonarrShow) {
+    return new TestResponse();
+  }
+
+  @Override
+  public TestResponse getMovieDownloadResponses(RadarrQueue radarrQueue) {
+    return new TestResponse(radarrQueue);
+  }
+
+  @Override
+  public TestResponse createErrorMessage(String message) {
+    return new TestResponse(message);
+  }
+
+  @Override
+  public TestResponse createInfoMessage(String message) {
+    return new TestResponse(message);
+  }
+
+  @Override
+  public TestResponse createSuccessMessage(String message) {
+    return new TestResponse(message);
+  }
+
+  @Override
+  public TestResponse getTorrentResponses(RadarrTorrent radarrTorrent, String movieTitle) {
+    return new TestResponse();
+  }
+
+  @Override
+  public TestResponse getShowProfile(SonarrProfile sonarrProfile) {
+    return new TestResponse();
+  }
+
+  @Override
+  public TestResponse getMovieProfile(RadarrProfile radarrProfile) {
+    return new TestResponse();
+  }
+
+  @Override
+  public TestResponse getNewOrExistingShow(SonarrShow sonarrShow, SonarrShow existingShow, boolean findNew) {
+    return new TestResponse();
+  }
+
+  @Override
+  public TestResponse getNewOrExistingMovie(RadarrMovie lookupMovie, RadarrMovie existingMovie, boolean findNew) {
+    return new TestResponse(lookupMovie);
+  }
+
+  @Override
+  public TestResponse getMovie(RadarrMovie radarrMovie) {
+    return new TestResponse(radarrMovie);
+  }
+
+  @Override
+  public TestResponse getDiscoverableMovies(RadarrMovie radarrMovie) {
+    return new TestResponse(radarrMovie);
+  }
+}

--- a/src/test/java/com/botdarr/api/ApiRequestsTests.java
+++ b/src/test/java/com/botdarr/api/ApiRequestsTests.java
@@ -1,6 +1,6 @@
-package com.botdarr;
+package com.botdarr.api;
 
-import com.botdarr.api.ApiRequests;
+import com.botdarr.Config;
 import com.botdarr.database.Bootstrap;
 import com.botdarr.database.DatabaseHelper;
 import mockit.*;

--- a/src/test/java/com/botdarr/commands/CommandProcessorTests.java
+++ b/src/test/java/com/botdarr/commands/CommandProcessorTests.java
@@ -1,0 +1,128 @@
+package com.botdarr.commands;
+
+import com.botdarr.TestResponse;
+import com.botdarr.TestResponseBuilder;
+import com.botdarr.api.RadarrApi;
+import com.botdarr.api.SonarrApi;
+import mockit.Injectable;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * These tests specifically test commands that take no arguments and commands that take arguments
+ */
+public class CommandProcessorTests {
+  @Before
+  public void beforeEachTest() {
+    mockCommandPrefix("!");
+  }
+
+  @Test
+  public void processMessage_validateHelpCommand() {
+    validateInvalidCommandIdentifier("!helpx");
+  }
+
+  @Test
+  public void processMessage_validateMoviesHelpCommand() {
+    validateNoArgCommands("!movies help");
+  }
+
+  @Test
+  public void processMessage_validateShowsHelpCommand() {
+    validateNoArgCommands("!shows help");
+  }
+
+  @Test
+  public void processMessage_validateMoviesDiscoverCommand() {
+    validateNoArgCommands("!movie discover");
+  }
+
+  @Test
+  public void processMessage_validateMovieProfilesCommand() {
+    validateNoArgCommands("!movie profiles");
+  }
+
+  @Test
+  public void processMessage_validateMovieDownloadsCommand() {
+    validateNoArgCommands("!movie downloads");
+  }
+
+  @Test
+  public void processMessage_validateShowDownloadsCommand() {
+    validateNoArgCommands("!show downloads");
+  }
+
+  @Test
+  public void processMessage_validateShowProfilesCommand() {
+    validateNoArgCommands("!show profiles");
+  }
+
+  @Test
+  public void processMessage_missingMovieTitleAddCommand() {
+    validateInvalidCommand("!movie id add 541515", "");
+  }
+
+  private void validateNoArgCommands(String command) {
+    //validate an extra character after the command is invalid
+    validateInvalidCommandIdentifier(command + "x");
+    //validate an extra space around the extra character after the command is invalid
+    validateInvalidCommandIdentifier(command + " x ");
+    //validate an extra space after the command is trimmed and the command is still valid
+    validateValidCommandIdentifier(command + " ");
+    //validate the command itself is valid
+    validateValidCommandIdentifier(command);
+  }
+
+  private void validateInvalidCommandIdentifier(String invalidCommand) {
+    validateInvalidCommand(invalidCommand, "Invalid command - type !help for command usage");
+  }
+
+  private void validateValidCommandIdentifier(String validCommand) {
+    CommandProcessor commandProcessor = new CommandProcessor();
+    CommandResponse<TestResponse> commandResponse =
+      commandProcessor.processMessage(getCommandsToTest(), validCommand, "user1", responseBuilder);
+    //we are just making sure no response is returned as another tests validates that part of the command/api
+    if (commandResponse.getSingleChatClientResponse() != null) {
+      Assert.assertNull(commandResponse.getSingleChatClientResponse().getResponseMessage());
+    }
+  }
+
+  private void validateInvalidCommand(String invalidCommand, String expectedMessage) {
+    CommandProcessor commandProcessor = new CommandProcessor();
+    CommandResponse<TestResponse> commandResponse =
+      commandProcessor.processMessage(getCommandsToTest(), invalidCommand, "user1", responseBuilder);
+    Assert.assertEquals(expectedMessage, commandResponse.getSingleChatClientResponse().getResponseMessage());
+  }
+
+  private void mockCommandPrefix(String prefix) {
+    new MockUp<CommandProcessor>() {
+      @Mock
+      String getPrefix() {
+        return prefix;
+      }
+    };
+  }
+
+  private List<Command> getCommandsToTest() {
+    List<Command> radarrCommands = RadarrCommands.getCommands(radarrApi);
+    List<Command> sonarrCommands = SonarrCommands.getCommands(sonarrApi);
+    List<Command> commands = new ArrayList<>(HelpCommands.getCommands(responseBuilder, radarrCommands, sonarrCommands));
+    commands.addAll(radarrCommands);
+    commands.addAll(sonarrCommands);
+    return commands;
+  }
+
+  @Injectable
+  private RadarrApi radarrApi;
+
+  @Injectable
+  private SonarrApi sonarrApi;
+
+  private TestResponseBuilder responseBuilder = new TestResponseBuilder();
+}

--- a/src/test/java/com/botdarr/commands/CommandProcessorTests.java
+++ b/src/test/java/com/botdarr/commands/CommandProcessorTests.java
@@ -128,6 +128,98 @@ public class CommandProcessorTests {
     validateValidCommand("!movie title add Princess 5");
   }
 
+  @Test
+  public void processMessage_invalidMovieTitleForFindNewMovieCommand() {
+    validateInvalidCommand("!movie find new",
+      "Error trying to parse command !movie find new, " +
+      "error=Movie title is missing");
+  }
+
+  @Test
+  public void processMessage_validMovieTitleForFindNewMovieCommand() {
+    new Expectations() {{
+      radarrApi.lookup("princess5", true); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!movie find new Princess5");
+  }
+
+  @Test
+  public void processMessage_validMovieTitleWithSpacesForFindNewMovieCommand() {
+    new Expectations() {{
+      radarrApi.lookup("princess 5", true); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!movie find new Princess 5");
+  }
+
+  @Test
+  public void processMessage_invalidMovieTitleForFindExistingMovieCommand() {
+    validateInvalidCommand("!movie find existing",
+      "Error trying to parse command !movie find existing, " +
+        "error=Movie title is missing");
+  }
+
+  @Test
+  public void processMessage_validMovieTitleForFindExistingMovieCommand() {
+    new Expectations() {{
+      radarrApi.lookup("princess5", false); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!movie find existing Princess5");
+  }
+
+  @Test
+  public void processMessage_validMovieTitleWithSpacesForFindExistingMovieCommand() {
+    new Expectations() {{
+      radarrApi.lookup("princess 5", false); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!movie find existing Princess 5");
+  }
+
+  @Test
+  public void processMessage_invalidMovieTitleForFindDownloadsCommand() {
+    validateInvalidCommand("!movie find downloads",
+      "Error trying to parse command !movie find downloads, " +
+        "error=Movie title is missing");
+  }
+
+  @Test
+  public void processMessage_validMovieTitleForFindDownloadsCommand() {
+    new Expectations() {{
+      radarrApi.lookupTorrents("princess5", false); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!movie find downloads Princess5");
+  }
+
+  @Test
+  public void processMessage_validMovieTitleWithSpacesForFindDownloadsCommand() {
+    new Expectations() {{
+      radarrApi.lookupTorrents("princess 5", false); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!movie find downloads Princess 5");
+  }
+
+  @Test
+  public void processMessage_invalidMovieTitleForFindAllDownloadsCommand() {
+    validateInvalidCommand("!movie find all downloads",
+      "Error trying to parse command !movie find all downloads, " +
+        "error=Movie title is missing");
+  }
+
+  @Test
+  public void processMessage_validMovieTitleForFindAllDownloadsCommand() {
+    new Expectations() {{
+      radarrApi.lookupTorrents("princess5", true); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!movie find all downloads Princess5");
+  }
+
+  @Test
+  public void processMessage_validMovieTitleWithSpacesForFindAllDownloadsCommand() {
+    new Expectations() {{
+      radarrApi.lookupTorrents("princess 5", true); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!movie find all downloads Princess 5");
+  }
+  
   private void validateNoArgCommands(String command) {
     //validate an extra character after the command is invalid
     validateInvalidCommandIdentifier(command + "x");

--- a/src/test/java/com/botdarr/commands/CommandProcessorTests.java
+++ b/src/test/java/com/botdarr/commands/CommandProcessorTests.java
@@ -219,7 +219,112 @@ public class CommandProcessorTests {
     }};
     validateValidCommand("!movie find all downloads Princess 5");
   }
-  
+
+  @Test
+  public void processMessage_missingShowTitleAndIdForAddCommand() {
+    validateInvalidCommand("!show id add",
+      "Error trying to parse command !show id add, " +
+        "error=Missing expected arguments - usage: show id add SHOW_TITLE_HERE SHOW_ID_HERE");
+  }
+
+  @Test
+  public void processMessage_missingShowTitleForAddCommand() {
+    validateInvalidCommand("!show id add 541515",
+      "Error trying to parse command !show id add 541515, " +
+        "error=Missing expected arguments - usage: show id add SHOW_TITLE_HERE SHOW_ID_HERE");
+  }
+
+  @Test
+  public void processMessage_missingShowIdForAddCommand() {
+    validateInvalidCommand("!show id add Princess5",
+      "Error trying to parse command !show id add Princess5, " +
+        "error=Missing expected arguments - usage: show id add SHOW_TITLE_HERE SHOW_ID_HERE");
+  }
+
+  @Test
+  public void processMessage_invalidShowIdForAddCommand() {
+    validateInvalidCommand("!show id add Princess5 4647x5",
+      "Error trying to parse command !show id add Princess5 4647x5, " +
+        "error=Show id is not a number");
+  }
+
+  @Test
+  public void processMessage_validShowTitleAndIdForAddCommand() {
+    new Expectations() {{
+      sonarrApi.addWithId("princess5", "46475"); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!show id add Princess5 46475");
+  }
+
+  @Test
+  public void processMessage_invalidShowTitleForAddCommand() {
+    validateInvalidCommand("!show title add",
+      "Error trying to parse command !show title add, " +
+        "error=Show title is missing");
+  }
+
+  @Test
+  public void processMessage_validShowTitleForAddCommand() {
+    new Expectations() {{
+      sonarrApi.addWithTitle("princess5"); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!show title add Princess5");
+  }
+
+  @Test
+  public void processMessage_validShowTitleWithSpacesForAddCommand() {
+    new Expectations() {{
+      sonarrApi.addWithTitle("princess 5"); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!show title add Princess 5");
+  }
+
+  @Test
+  public void processMessage_invalidShowTitleForFindNewShowCommand() {
+    validateInvalidCommand("!show find new",
+      "Error trying to parse command !show find new, " +
+        "error=Show title is missing");
+  }
+
+  @Test
+  public void processMessage_validShowTitleForFindNewShowCommand() {
+    new Expectations() {{
+      sonarrApi.lookup("princess5", true); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!show find new Princess5");
+  }
+
+  @Test
+  public void processMessage_validShowTitleWithSpacesForFindNewShowCommand() {
+    new Expectations() {{
+      sonarrApi.lookup("princess 5", true); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!show find new Princess 5");
+  }
+
+  @Test
+  public void processMessage_invalidShowTitleForFindExistingShowCommand() {
+    validateInvalidCommand("!show find existing",
+      "Error trying to parse command !show find existing, " +
+        "error=Show title is missing");
+  }
+
+  @Test
+  public void processMessage_validShowTitleForFindExistingShowCommand() {
+    new Expectations() {{
+      sonarrApi.lookup("princess5", false); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!show find existing Princess5");
+  }
+
+  @Test
+  public void processMessage_validShowTitleWithSpacesForFindExistingShowCommand() {
+    new Expectations() {{
+      sonarrApi.lookup("princess 5", false); times = 1; result = new TestResponse();
+    }};
+    validateValidCommand("!show find existing Princess 5");
+  }
+
   private void validateNoArgCommands(String command) {
     //validate an extra character after the command is invalid
     validateInvalidCommandIdentifier(command + "x");

--- a/src/test/java/com/botdarr/commands/ContextTests.java
+++ b/src/test/java/com/botdarr/commands/ContextTests.java
@@ -1,6 +1,5 @@
-package com.botdarr;
+package com.botdarr.commands;
 
-import com.botdarr.commands.CommandContext;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Added test cases for various radarr/sonarr command variations (and some error handling)
Let users configure any prefix using the following property: command-prefix